### PR TITLE
Change toString so that enum's print error code by default

### DIFF
--- a/common/src/main/java/net/sf/webdav/WebdavStatus.java
+++ b/common/src/main/java/net/sf/webdav/WebdavStatus.java
@@ -231,6 +231,13 @@ public enum WebdavStatus
         return message;
     }
 
+ 
+    public String toString()
+    {
+        return ""+ code;
+    }
+
+    
     public static WebdavStatus get( final int status )
     {
         for ( final WebdavStatus stat : values() )


### PR DESCRIPTION
which is the way they are used. Nasty by effective solution to problem https://github.com/jdcasey/webdav-handler/issues/1
