### PR TITLE
refactor 'setResourceContent' method

### DIFF
--- a/common/src/main/java/net/sf/webdav/impl/LocalFileSystemStore.java
+++ b/common/src/main/java/net/sf/webdav/impl/LocalFileSystemStore.java
@@ -148,8 +148,7 @@ public class LocalFileSystemStore
     }
 
     @Override
-    public long setResourceContent( final ITransaction transaction, final String uri, final InputStream is, final String contentType,
-                                    final String characterEncoding )
+    public long setResourceContent(final ITransaction transaction, final String uri, final InputStream is, long contentLength)
         throws WebdavException
     {
 

--- a/common/src/main/java/net/sf/webdav/methods/DoCopy.java
+++ b/common/src/main/java/net/sf/webdav/methods/DoCopy.java
@@ -290,7 +290,7 @@ public class DoCopy
         {
             _store.createResource( transaction, destinationPath );
             final long resourceLength =
-                _store.setResourceContent( transaction, destinationPath, _store.getResourceContent( transaction, sourcePath ), null, null );
+                _store.setResourceContent( transaction, destinationPath, _store.getResourceContent( transaction, sourcePath ), sourceSo.getResourceLength());
 
             if ( resourceLength != -1 )
             {
@@ -368,7 +368,7 @@ public class DoCopy
                         _store.createResource( transaction, destinationPath + children[i] );
                         final long resourceLength =
                             _store.setResourceContent( transaction, destinationPath + children[i],
-                                                       _store.getResourceContent( transaction, sourcePath + children[i] ), null, null );
+                                                       _store.getResourceContent( transaction, sourcePath + children[i] ), childSo.getResourceLength());
 
                         if ( resourceLength != -1 )
                         {

--- a/common/src/main/java/net/sf/webdav/methods/DoPut.java
+++ b/common/src/main/java/net/sf/webdav/methods/DoPut.java
@@ -176,7 +176,7 @@ public class DoPut
                     doUserAgentWorkaround( resp );
 
                     // setting resourceContent
-                    final long resourceLength = _store.setResourceContent( transaction, path, req.getInputStream(), null, null );
+                    final long resourceLength = _store.setResourceContent( transaction, path, req.getInputStream(), req.getContentLength());
 
                     so = _store.getStoredObject( transaction, path );
                     if ( resourceLength != -1 )

--- a/common/src/main/java/net/sf/webdav/spi/IWebdavStore.java
+++ b/common/src/main/java/net/sf/webdav/spi/IWebdavStore.java
@@ -146,16 +146,12 @@ public interface IWebdavStore
      *      URI of the resource where the content will be stored
      * @param content
      *      input stream from which the content will be read from
-     * @param contentType
-     *      content type of the resource or <code>null</code> if unknown
-     * @param characterEncoding
-     *      character encoding of the resource or <code>null</code> if unknown
-     *      or not applicable
+     * @param contentLength The length of the content.
      * @return lenght of resource
      * @throws WebdavException
      *      if something goes wrong on the store level
      */
-    long setResourceContent( ITransaction transaction, String resourceUri, InputStream content, String contentType, String characterEncoding )
+    long setResourceContent(ITransaction transaction, String resourceUri, InputStream content, long contentLength)
         throws WebdavException;
 
     /**

--- a/common/src/test/java/net/sf/webdav/methods/DoCopyTest.java
+++ b/common/src/test/java/net/sf/webdav/methods/DoCopyTest.java
@@ -282,7 +282,7 @@ public class DoCopyTest
                 one( mockStore ).getResourceContent( mockTransaction, sourceFilePath );
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, resourceLength );
                 will( returnValue( resourceLength ) );
 
                 destFileSo = initFileStoredObject( resourceContent );
@@ -455,7 +455,7 @@ public class DoCopyTest
                 one( mockStore ).getResourceContent( mockTransaction, sourceFilePath );
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, destCollectionPath + "/sourceFile", bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, destCollectionPath + "/sourceFile", bais, resourceLength );
 
                 final StoredObject destFileSo = initFileStoredObject( resourceContent );
 
@@ -596,7 +596,7 @@ public class DoCopyTest
                 one( mockStore ).getResourceContent( mockTransaction, sourceFilePath );
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, resourceLength );
 
                 one( mockStore ).getStoredObject( mockTransaction, destFilePath );
                 will( returnValue( existingDestSo ) );
@@ -737,7 +737,7 @@ public class DoCopyTest
                 one( mockStore ).getResourceContent( mockTransaction, sourceFilePath );
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, resourceLength );
 
                 one( mockStore ).getStoredObject( mockTransaction, destFilePath );
                 will( returnValue( destFileSo ) );

--- a/common/src/test/java/net/sf/webdav/methods/DoMoveTest.java
+++ b/common/src/test/java/net/sf/webdav/methods/DoMoveTest.java
@@ -151,7 +151,7 @@ public class DoMoveTest
                 one( mockStore ).getResourceContent( mockTransaction, sourceFilePath );
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, resourceLength );
                 will( returnValue( 8L ) );
 
                 destFileSo = initFileStoredObject( resourceContent );
@@ -304,7 +304,7 @@ public class DoMoveTest
                 one( mockStore ).getResourceContent( mockTransaction, sourceFilePath );
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, destFilePath, bais, resourceLength );
                 will( returnValue( 8L ) );
 
                 one( mockStore ).getStoredObject( mockTransaction, destFilePath );
@@ -508,7 +508,7 @@ public class DoMoveTest
                 one( mockStore ).getResourceContent( mockTransaction, sourceCollectionPath + "/sourceFile" );
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, destCollectionPath + "/sourceFile", bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, destCollectionPath + "/sourceFile", bais, resourceLength );
                 will( returnValue( 8L ) );
 
                 final StoredObject movedSo = initFileStoredObject( resourceContent );
@@ -694,7 +694,7 @@ public class DoMoveTest
                 one( mockStore ).getResourceContent( mockTransaction, sourceFilePath );
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, overwritePath + "/sourceFile", bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, overwritePath + "/sourceFile", bais, resourceLength );
 
                 final StoredObject movedSo = initFileStoredObject( resourceContent );
 

--- a/common/src/test/java/net/sf/webdav/methods/DoPutTest.java
+++ b/common/src/test/java/net/sf/webdav/methods/DoPutTest.java
@@ -96,6 +96,9 @@ public class DoPutTest
                 one( mockReq ).getHeader( "User-Agent" );
                 will( returnValue( "Goliath agent" ) );
 
+                one( mockReq ).getContentLength();
+                will( returnValue( (int) resourceLength ) );
+
                 final StoredObject parentSo = initFolderStoredObject();
 
                 one( mockStore ).getStoredObject( mockTransaction, parentPath );
@@ -113,7 +116,7 @@ public class DoPutTest
                 one( mockReq ).getInputStream();
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, path, bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, path, bais, resourceLength );
                 will( returnValue( 8L ) );
 
                 fileSo = initFileStoredObject( resourceContent );
@@ -190,6 +193,9 @@ public class DoPutTest
                 one( mockReq ).getHeader( "User-Agent" );
                 will( returnValue( "WebDAVFS/1.5.0 (01500000) ....." ) );
 
+                one( mockReq ).getContentLength();
+                will( returnValue( (int) resourceLength ) );
+
                 final StoredObject parentSo = null;
 
                 one( mockStore ).getStoredObject( mockTransaction, parentPath );
@@ -209,7 +215,7 @@ public class DoPutTest
                 one( mockReq ).getInputStream();
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, path, bais, null, null );
+                one( mockStore ).setResourceContent( mockTransaction, path, bais, resourceLength );
                 will( returnValue( 8L ) );
 
                 fileSo = initFileStoredObject( resourceContent );
@@ -419,7 +425,10 @@ public class DoPutTest
                 one( mockReq ).getInputStream();
                 will( returnValue( bais ) );
 
-                one( mockStore ).setResourceContent( mockTransaction, path, bais, null, null );
+                one( mockReq ).getContentLength();
+                will( returnValue( (int) resourceLength ) );
+
+                one( mockStore ).setResourceContent( mockTransaction, path, bais, resourceLength );
                 will( returnValue( 8L ) );
 
                 final StoredObject newResourceSo = initFileStoredObject( resourceContent );


### PR DESCRIPTION
I'm working on an implementation of `IWebdavStore` that uses Amazon S3 as a back-end. This refactor removes some unused parameters and as a needed `contentLength` parameter to the `setResourceContent` method to make the S3 implementation easier.

In addition to the request to merge these changes, I have a question: I'd be happy to contribute my S3 implementation to the project. If I submitted another pull request including this code, would it be accepted? Or is that outside the scope of this project?

It seems like it's not outside the scope of the project, since the project already comes with a default filesystem implementation.

Thanks!